### PR TITLE
Fix SPR2 register compilation error for 8MHz ATmega32U4 boards

### DIFF
--- a/src/arduino_psx.cpp
+++ b/src/arduino_psx.cpp
@@ -30,7 +30,8 @@ void PSX_::init(int ackPin = 8, bool invACK = false, bool invCIPO = true) {
 #if (F_CPU == 16000000L)
     SPCR |= (1 << SPR1);  // Fosc/64 @16MHz==250KHz
 #elif (F_CPU == 8000000L)
-    SPCR |= (1 << SPR2) | (1 << SPR1);  // Fosc/32 @8MHz==250KHz
+    SPCR |= (1 << SPR1);    // SPR1=1, SPR0=0 for Fosc/64 base
+    SPSR |= (1 << SPI2X);   // SPI2X=1 for double speed -> Fosc/32 @8MHz==250KHz
 #endif
     SPCR |= (1 << CPHA);  // Setup @ leading edge, sample @ falling edge
     SPCR |= (1 << CPOL);  // Leading edge is falling edge, trailing edge is rising edge


### PR DESCRIPTION
## Problem

The code currently uses `SPR2` register bit which does not exist in ATmega32U4, causing compilation errors on some development environments:

```
error: 'SPR2' was not declared in this scope
```

This issue primarily affects **3.3V 8MHz ATmega32U4 boards** (such as some SparkFun Pro Micro 3.3V variants) when compiled with strict register checking.

## Background
- Most ATmega32U4 boards (Leonardo, Micro, standard Pro Micro) operate at **5V 16MHz** and work fine with the current code
- The issue specifically occurs with **3.3V 8MHz variants** where the SPR2 register reference causes compilation failures
- The original code attempts to set SPI clock to 250kHz using non-existent SPR2 bit

## Solution

Replace the non-existent `SPR2` with the correct combination of `SPR1` and `SPI2X` bits to achieve the same Fosc/32 clock division:
- `SPR1=1, SPR0=0` → Fosc/64
- `SPI2X=1` → Double speed mode → Fosc/32
- Result: 8MHz/32 = 250kHz (maintains original target frequency)
